### PR TITLE
Updating to fix bug related to opening new instances of Xcode when using xcode-select path

### DIFF
--- a/xopen
+++ b/xopen
@@ -23,12 +23,10 @@ function seek_and_project {
 	if $found_flag; then
 		current_tools_path=`xcode-select -p`
 		contents_path=${current_tools_path%/*}
+		xcode_app_path=${contents_path%/*}
 
-		xcode_path=${contents_path}"/MacOS/Xcode"
-		full_project_path=$(pwd)/$project_file
-
-		echo "Opening ${full_project_path}"
-		nohup ${xcode_path} "${full_project_path}" </dev/null >/dev/null 2>&1 &
+		echo "Opening ${project_file}"
+		open -a $xcode_app_path $project_file
 		exit
 	fi
 }


### PR DESCRIPTION
So, turns out using `nohup` opens up new instances of Xcode each time you open a project/workspace.

I just found out this very simple way to achieve the same thing we were trying to do and it seems it works just nicely.

Hope it helps.