### PR TITLE
sudo not needed in general unless a previous wrong installation is detected

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,8 +1,8 @@
-if [  -e /usr/bin/xopen ]; then
+if [  -e /usr/local/bin/xopen ]; then
 	echo "\033[0;33mYou already have xopen installed. You already are a happy guy with a fantastic shor usefull script\033[0m"
 	echo "\033[0;33mWe are justing updating your xopen\033[0m"
 fi
-echo "\033[0;34mMaking some fucking configurations, maybe I'll need some fucking sudoers permission to accomplish this.\033[0m"
+
 echo "\033[0;34mGetting xopen DUDE!\033[0m"
 
 if [ -d ~/.xopen ]; then
@@ -14,10 +14,11 @@ hash git >/dev/null && /usr/bin/env git clone https://github.com/paulomendes/xop
   exit
 }
 
-sudo rm -f /usr/bin/xopen
+# in case that the file was misplaced before
+[ -f /usr/bin/xopen ] && sudo rm -f /usr/bin/xopen
 echo "\033[0;34mAlmost There\033[0m"
 
-sudo mv ~/.xopen/xopen /usr/local/bin/xopen
+mv ~/.xopen/xopen /usr/local/bin/xopen
 
 echo "\033[0;34mClearing all the fucking mess\033[0m"
 
@@ -30,6 +31,6 @@ echo "\033[0;34m  |   / / / / /_/ / __/ /  |/ / \033[0m"
 echo "\033[0;34m /   / /_/ / ____/ /___/ /|  /  \033[0m"
 echo "\033[0;34m/_/|_\____/_/   /_____/_/ |_/   \033[0m"
 echo ""
-echo ""  
+echo ""
 
 rm -rf ~/.xopen


### PR DESCRIPTION
The sudo-thing is not really necessary here unless a former installation landet in /usr/bin/ instead of /usr/local/bin.

My PR take this into account and removes the sudo-need for all other cases