### PR TITLE
react-native support

### DIFF
--- a/xopen
+++ b/xopen
@@ -34,4 +34,10 @@ function seek_and_project {
 seek_and_project "xcworkspace"
 seek_and_project "xcodeproj"
 
+if [ -f package.json ] && [ -d ios ]; then
+	cd ios && echo "Seems to be a React-Native application"
+	seek_and_project "xcworkspace"
+	seek_and_project "xcodeproj"
+fi
+
 echo "There is no project in this folder, buddy!"


### PR DESCRIPTION
This PR will make xopen able to support also react-native-applications.

RN-apps consists at least of a file called "package.json" and also a directory "ios" in root folder, if ios-support is present.

With this PR, we check if both things are existing, change dir into the ios part and repeat the search for either xcworkspace or xcodeproj.

Note: the "cd" command will not persist the changed directory. After execution of this shell script the former directory will be still active.