### PR TITLE
Make sure only real files are found

### DIFF
--- a/xopen
+++ b/xopen
@@ -28,15 +28,15 @@ function seek_and_project {
 	fi
 }
 
-seek_and_project "xcworkspace"
-seek_and_project "xcodeproj"
-seek_and_project "playground"
-seek_and_project "swift"
+seek_and_project ".xcworkspace"
+seek_and_project ".xcodeproj"
+seek_and_project ".playground"
+seek_and_project ".swift"
 
 if [ -f package.json ] && [ -d ios ]; then
 	cd ios && echo "Seems to be a React-Native application"
-	seek_and_project "xcworkspace"
-	seek_and_project "xcodeproj"
+	seek_and_project ".xcworkspace"
+	seek_and_project ".xcodeproj"
 fi
 
 echo "There is no project/playground in this folder, buddy!"


### PR DESCRIPTION
I have a project where `xopen` fails because one the files is literally named `xcodeproj`, so it mistakes it for being a project file. This PR modifies the script so that the lookup searches for actual files, thus fixing this specific problem.